### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/gossm.rb
+++ b/gossm.rb
@@ -6,7 +6,6 @@ class Gossm < Formula
   desc "gossm is interactive CLI tool that you select server in AWS and then could connect or send files your AWS server using start-session, ssh, scp under AWS Systems Manger."
   homepage ""
   version "1.4.4"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
This removes the deprecated call to `bottle :unneeded`.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the gjbae1212/gossm tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/gjbae1212/homebrew-gossm/gossm.rb:9
```